### PR TITLE
feat: allow case sum to be aliased

### DIFF
--- a/sq_helpers.go
+++ b/sq_helpers.go
@@ -11,13 +11,25 @@ type CaseSumBuilder struct {
 	Target    string
 	Condition string
 	Args      []interface{}
+	As        string
 }
 
 func (cs CaseSumBuilder) ToSql() (string, []interface{}, error) {
-	return fmt.Sprintf(`COALESCE(SUM(CASE WHEN %s THEN COALESCE(%s,0) ELSE 0 END), 0)`,
+	statement := fmt.Sprintf(`COALESCE(SUM(CASE WHEN %s THEN COALESCE(%s,0) ELSE 0 END), 0)`,
 		cs.Condition,
 		cs.Target,
-	), cs.Args, nil
+	)
+
+	if cs.As != "" {
+		statement = fmt.Sprintf("%s AS %s", statement, cs.As)
+	}
+
+	return statement, cs.Args, nil
+}
+
+func (cs *CaseSumBuilder) Alias(as string) *CaseSumBuilder {
+	cs.As = as
+	return cs
 }
 
 func CaseSum(target, condition string, args ...interface{}) *CaseSumBuilder {

--- a/sq_helpers_test.go
+++ b/sq_helpers_test.go
@@ -25,6 +25,16 @@ func compareSQL(t testing.TB, stmt Sqlizer, wantText string, wantArgs ...interfa
 
 }
 
+func TestCaseSumSimple(t *testing.T) {
+	cs := CaseSum("amount", "amount > 0")
+	compareSQL(t, cs, "COALESCE(SUM(CASE WHEN amount > 0 THEN COALESCE(amount,0) ELSE 0 END), 0)")
+}
+
+func TestCaseSumAliased(t *testing.T) {
+	cs := CaseSum("amount", "amount > 0").Alias("positive_amount")
+	compareSQL(t, cs, "COALESCE(SUM(CASE WHEN amount > 0 THEN COALESCE(amount,0) ELSE 0 END), 0) AS positive_amount")
+}
+
 func TestUpsertSimple(t *testing.T) {
 
 	b := Upsert("table").Key("id", 1234).Set("data", "ASDF")


### PR DESCRIPTION
I ran into a situation where it would be nice to be able to alias CaseSums.

Tests are passing.